### PR TITLE
chore: adiciona dependencia spring validation e cria handler customizado

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,10 @@
 			<version>${org.mapstruct.version}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/br/com/booksy/Booksy/exception/ExceptionDetails.java
+++ b/src/main/java/br/com/booksy/Booksy/exception/ExceptionDetails.java
@@ -1,0 +1,11 @@
+package br.com.booksy.Booksy.exception;
+
+import lombok.Data;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+public class ExceptionDetails {
+    protected String title;
+    protected int status;
+}

--- a/src/main/java/br/com/booksy/Booksy/exception/ValidationExceptionDetails.java
+++ b/src/main/java/br/com/booksy/Booksy/exception/ValidationExceptionDetails.java
@@ -3,9 +3,10 @@ package br.com.booksy.Booksy.exception;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
+import java.util.Map;
+
 @Getter
 @SuperBuilder
 public class ValidationExceptionDetails extends ExceptionDetails{
-    private final String fields;
-    private final String fieldsMessage;
+    private final Map<String, String> fieldErrors;
 }

--- a/src/main/java/br/com/booksy/Booksy/exception/ValidationExceptionDetails.java
+++ b/src/main/java/br/com/booksy/Booksy/exception/ValidationExceptionDetails.java
@@ -1,0 +1,11 @@
+package br.com.booksy.Booksy.exception;
+
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class ValidationExceptionDetails extends ExceptionDetails{
+    private final String fields;
+    private final String fieldsMessage;
+}

--- a/src/main/java/br/com/booksy/Booksy/handler/RestExceptionHandler.java
+++ b/src/main/java/br/com/booksy/Booksy/handler/RestExceptionHandler.java
@@ -1,0 +1,34 @@
+package br.com.booksy.Booksy.handler;
+
+import br.com.booksy.Booksy.exception.ValidationExceptionDetails;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@ControllerAdvice
+public class RestExceptionHandler extends ResponseEntityExceptionHandler {
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
+        String fields = fieldErrors.stream().map(FieldError::getField).collect(Collectors.joining(", "));
+        String fieldsMessage = fieldErrors.stream().map(FieldError::getDefaultMessage).collect(Collectors.joining(", "));
+
+        return new ResponseEntity<>(
+                ValidationExceptionDetails.builder()
+                        .status(HttpStatus.BAD_REQUEST.value())
+                        .title("Invalid fields")
+                        .fields(fields)
+                        .fieldsMessage(fieldsMessage)
+                        .build(), HttpStatus.BAD_REQUEST
+        );
+    }
+}

--- a/src/main/java/br/com/booksy/Booksy/handler/RestExceptionHandler.java
+++ b/src/main/java/br/com/booksy/Booksy/handler/RestExceptionHandler.java
@@ -12,22 +12,23 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @ControllerAdvice
 public class RestExceptionHandler extends ResponseEntityExceptionHandler {
     @Override
     protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-        List<FieldError> fieldErrors = ex.getBindingResult().getFieldErrors();
-        String fields = fieldErrors.stream().map(FieldError::getField).collect(Collectors.joining(", "));
-        String fieldsMessage = fieldErrors.stream().map(FieldError::getDefaultMessage).collect(Collectors.joining(", "));
+        Map<String, String> fieldErrorsMap = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .collect(Collectors.toMap(FieldError::getField, FieldError::getDefaultMessage, (msg1, msg2) -> msg1));
 
         return new ResponseEntity<>(
                 ValidationExceptionDetails.builder()
                         .status(HttpStatus.BAD_REQUEST.value())
                         .title("Invalid fields")
-                        .fields(fields)
-                        .fieldsMessage(fieldsMessage)
+                        .fieldErrors(fieldErrorsMap)
                         .build(), HttpStatus.BAD_REQUEST
         );
     }


### PR DESCRIPTION
Proposta de estratégia para lidar com validação nas requisições.

Quando alguma annotation do Spring Validation jogar exception do tipo MethodArgumentNotValidException, a resposta do endpoint vai ser no seguinte formato:

{
    "title": "Invalid fields",
    "status": 400,
    "fields": "campo, outroCampo",
    "fieldsMessage": "Mensagem definida em DTO, Mensagem definida em DTO" 
}